### PR TITLE
Openneuropet apptainer

### DIFF
--- a/.github/workflows/test-apptainer-upload.yml
+++ b/.github/workflows/test-apptainer-upload.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Debug
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        timeout-minutes: 15
+        timeout-minutes: 360
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/test-apptainer-upload.yml
+++ b/.github/workflows/test-apptainer-upload.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - openneuropet_apptainer
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
 
 jobs:
   build-and-test:
@@ -242,6 +249,14 @@ jobs:
         if: steps.test-data-cache.outputs.cache-hit != 'true'
         run: |
           make get-test-data
+
+      
+      - name: Debug
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
       - name: Run upload test
         run: make test-upload


### PR DESCRIPTION
Added debugging step to actions that fires on manual trigger of action.

Noticed that when I tried reproducing the action `Test Apptainer Upload` that the containers weren't running but ezBIDS was still reachable at localhost:3000. Am able to reproduce what I encountered locally via this PR. Below one can see that the ezBIDS api is up an running despite no containers being active:

```
runner@runnervmf4ws1:~/work/ezbids/ezbids$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
runner@runnervmf4ws1:~/work/ezbids/ezbids$ apptainer instance list
INSTANCE NAME    PID    IP    IMAGE
runner@runnervmf4ws1:~/work/ezbids/ezbids$ curl localhost:3000
runner@runnervmf4ws1:~/work/ezbids/ezbids$ curl localhost:8082
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /</pre>
</body>
</html>
runner@runnervmf4ws1:~/work/ezbids/ezbids$
```

To reproduce, merge this PR then ssh into the runner with the command generated by [mxschmitt/action-tmate@v3](https://github.com/marketplace/actions/debugging-with-tmate)

Action needs to be manually triggered to debug with how I set this up, but I think that's better anyway.

Thanks.